### PR TITLE
DYOM Translation - Support for modded in languages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .ccls-cache
 bin/
 bin_rel/
+/.vs
+/build

--- a/config.toml
+++ b/config.toml
@@ -344,10 +344,8 @@ RandomSpawn = true
 # Languages in translation chain separated by a semicolon, e.g. "pl;el;zh-CN;en" means Polish->Greek->Simplified Chinese->English, see https://cloud.google.com/translate/docs/languages for supported languages and their codes
 TranslationChain = "en"
 
-#Original language unicode characters each followed by a semicolon
-#InputCharacters = "А;Б;В;Г;Д;Е;Ё;Ж;З;И;Й;К;Л;М;Н;О;П;Р;С;Т;У;Ф;Х;Ц;Ч;Ш;Щ;Ъ;Ы;Ь;Э;Ю;Я;а;б;в;г;д;е;ё;ж;з;и;й;к;л;м;н;о;п;р;с;т;у;ф;х;ц;ч;ш;щ;ъ;ы;ь;э;ю;я;"
-#Bytes of corresponding in-game characters (GTA SA uses Windows-1252)
-#OutputCharacters = "AE¨K­OPCYXa¢e¸k¯®o£pc¦yx ¤¥¡§¨©ª«¬"
+#Character replacement pairs. Original unicode symbol must be followed by the byte of it's in-game counterpart (GTA SA uses Windows-1252)
+#CharactersMap = "А;41;Б;80;В;8B;Г;82;Д;83;Е;45;Ё;A8;Ж;84;З;88;И;85;Й;86;К;4B;Л;87;М;96;Н;AD;О;4F;П;8C;Р;50;С;43;Т;8F;У;59;Ф;81;Х;58;Ц;89;Ч;8D;Ш;8E;Щ;8A;Ъ;90;Ы;91;Ь;92;Э;93;Ю;94;Я;95;а;61;б;97;в;A2;г;99;д;9A;е;65;ё;B8;ж;9B;з;9F;и;9C;й;9D;к;6B;л;9E;м;AF;н;AE;о;6F;п;A3;р;70;с;63;т;A6;у;79;ф;98;х;78;ц;A0;ч;A4;ш;A5;щ;A1;ъ;A7;ы;A8;ь;A9;э;AA;ю;AB;я;AC"
 
 #######################################################
 [CheatRandomizer]

--- a/config.toml
+++ b/config.toml
@@ -338,6 +338,17 @@ RandomizeChaosPoints = false
 # Picks missions only from those designated as English by the DYOM website.
 UseEnglishOnlyFilter = false
 
+AutoTranslateToEnglish = true
+RandomSpawn = true
+
+# Languages in translation chain separated by a semicolon, e.g. "pl;el;zh-CN;en" means Polish->Greek->Simplified Chinese->English, see https://cloud.google.com/translate/docs/languages for supported languages and their codes
+TranslationChain = "en"
+
+#Original language unicode characters each followed by a semicolon
+#InputCharacters = "А;Б;В;Г;Д;Е;Ё;Ж;З;И;Й;К;Л;М;Н;О;П;Р;С;Т;У;Ф;Х;Ц;Ч;Ш;Щ;Ъ;Ы;Ь;Э;Ю;Я;а;б;в;г;д;е;ё;ж;з;и;й;к;л;м;н;о;п;р;с;т;у;ф;х;ц;ч;ш;щ;ъ;ы;ь;э;ю;я;"
+#Bytes of corresponding in-game characters (GTA SA uses Windows-1252)
+#OutputCharacters = "AE¨K­OPCYXa¢e¸k¯®o£pc¦yx ¤¥¡§¨©ª«¬"
+
 #######################################################
 [CheatRandomizer]
 

--- a/include/dyom.hh
+++ b/include/dyom.hh
@@ -37,6 +37,8 @@ public:
         bool        EnableTextToSpeech;
         bool        RandomSpawn;
         std::string TranslationChain;
+        std::string InputCharacters;
+        std::string OutputCharacters;
         double      OverrideTTSVolume;
     } m_Config;
 

--- a/include/dyom.hh
+++ b/include/dyom.hh
@@ -37,8 +37,7 @@ public:
         bool        EnableTextToSpeech;
         bool        RandomSpawn;
         std::string TranslationChain;
-        std::string InputCharacters;
-        std::string OutputCharacters;
+        std::string CharactersMap;
         double      OverrideTTSVolume;
     } m_Config;
 

--- a/include/util/dyom/Translation.hh
+++ b/include/util/dyom/Translation.hh
@@ -3,6 +3,7 @@
 #include <sstream>
 #include <string>
 #include <regex>
+#include <map>
 
 #include <windows.h>
 #include <wininet.h>
@@ -24,7 +25,9 @@ class DyomTranslator
     void ProcessDidTranslate (std::string translated);
 
 public:
-    DyomTranslator (const std::string &translationChain = "");
+    DyomTranslator (const std::string &translationChain = "",
+                    const std::string &inputCharacters = "",
+                    const std::string &outputCharacters  = "");
     ~DyomTranslator () { internet.Close (); }
 
     void FixupGxtTokens (std::string &text);
@@ -44,4 +47,5 @@ public:
     }
 
     std::vector<std::string> mTranslationChain;
+    std::map<std::string, std::string> mCharacterMap;
 };

--- a/include/util/dyom/Translation.hh
+++ b/include/util/dyom/Translation.hh
@@ -26,8 +26,7 @@ class DyomTranslator
 
 public:
     DyomTranslator (const std::string &translationChain = "",
-                    const std::string &inputCharacters = "",
-                    const std::string &outputCharacters  = "");
+                    const std::string &charactersMap = "");
     ~DyomTranslator () { internet.Close (); }
 
     void FixupGxtTokens (std::string &text);
@@ -47,5 +46,5 @@ public:
     }
 
     std::vector<std::string> mTranslationChain;
-    std::map<std::string, std::string> mCharacterMap;
+    std::map<std::string, char> mCharacterMap;
 };

--- a/src/dyom.cc
+++ b/src/dyom.cc
@@ -139,6 +139,8 @@ DyomRandomizer::Initialise ()
             std::pair ("UseEnglishOnlyFilter", &m_Config.EnglishOnly),
             std::pair ("RandomSpawn", &m_Config.RandomSpawn),
             std::pair ("TranslationChain", &m_Config.TranslationChain),
+            std::pair ("InputCharacters", &m_Config.InputCharacters),
+            std::pair ("OutputCharacters", &m_Config.OutputCharacters),
             std::pair ("EnableTextToSpeech", &m_Config.EnableTextToSpeech),
             std::pair ("OverrideTTSVolume", &m_Config.OverrideTTSVolume),
             std::pair ("AutoTranslateToEnglish",
@@ -254,7 +256,9 @@ void
 DyomRandomizer::SaveMission (const std::vector<uint8_t> &data)
 {
     DYOM::DYOMFileStructure dyomFile;
-    DyomTranslator          translator (m_Config.TranslationChain);
+    DyomTranslator          translator (m_Config.TranslationChain,
+                               m_Config.InputCharacters,
+                               m_Config.OutputCharacters);
 
     dyomFile.Read (data);
 

--- a/src/dyom.cc
+++ b/src/dyom.cc
@@ -139,8 +139,7 @@ DyomRandomizer::Initialise ()
             std::pair ("UseEnglishOnlyFilter", &m_Config.EnglishOnly),
             std::pair ("RandomSpawn", &m_Config.RandomSpawn),
             std::pair ("TranslationChain", &m_Config.TranslationChain),
-            std::pair ("InputCharacters", &m_Config.InputCharacters),
-            std::pair ("OutputCharacters", &m_Config.OutputCharacters),
+            std::pair ("CharactersMap", &m_Config.CharactersMap),
             std::pair ("EnableTextToSpeech", &m_Config.EnableTextToSpeech),
             std::pair ("OverrideTTSVolume", &m_Config.OverrideTTSVolume),
             std::pair ("AutoTranslateToEnglish",
@@ -257,8 +256,7 @@ DyomRandomizer::SaveMission (const std::vector<uint8_t> &data)
 {
     DYOM::DYOMFileStructure dyomFile;
     DyomTranslator          translator (m_Config.TranslationChain,
-                               m_Config.InputCharacters,
-                               m_Config.OutputCharacters);
+                               m_Config.CharactersMap);
 
     dyomFile.Read (data);
 

--- a/src/util/dyom/Translation.cc
+++ b/src/util/dyom/Translation.cc
@@ -56,8 +56,7 @@ EncodeURL (const std::string &s)
 
 /*******************************************************/
 DyomTranslator::DyomTranslator (const std::string &translationChain,
-                                const std::string &inputCharacters,
-                                const std::string &outputCharacters)
+                                const std::string &charactersMap)
 {
     internet.Open ("translate.google.com");
 
@@ -71,17 +70,18 @@ DyomTranslator::DyomTranslator (const std::string &translationChain,
                 mTranslationChain.push_back (std::move (token));
         }
 
-    if (!inputCharacters.empty () && !outputCharacters.empty ()
-        && std::count (inputCharacters.begin (), inputCharacters.end (), ';')
-               == outputCharacters.length ())
+    if (!charactersMap.empty ())
         {
-            std::istringstream iss (inputCharacters);
-            int                i = 0;
-            for (std::string token; std::getline (iss, token, ';');)
+            std::istringstream iss (charactersMap);
+            std::string        token_v;
+            char               ch = '0';
+            for (std::string token; std::getline (iss, token, ';')
+                                    && std::getline (iss, token_v, ';');)
                 {
-                    mCharacterMap.insert (std::pair<std::string, std::string> (
+                    ch = (char)std::stoi (token_v, nullptr, 16);
+                    mCharacterMap.insert (std::pair<std::string, char> (
                         std::move (token),
-                        outputCharacters.substr (i++, 1)));
+                        ch));
                 }
         }
 }
@@ -227,7 +227,7 @@ DyomTranslator::TranslateText (const std::string &text)
             std::string::size_type pos = 0;
             while ((pos = translation.find (key, pos)) != std::string::npos)
                 {
-                    translation.replace (pos, key.length(), value);
+                    translation.replace (pos, key.length(), 1, value);
                     pos += 1;
                 }
         }


### PR DESCRIPTION
This feature adds ability to map unicode characters to single byte characters used by the game.
That means languages with non-latin script (e.g. Cyrillic) now can be correctly displayed by DYOM after translating to this language (with proper mapping of course).

For example, below config is for Russian localisation by San-Ltd:
TranslationChain = "ru"
CharactersMap = "А;41;Б;80;В;8B;Г;82;Д;83;Е;45;Ё;A8;Ж;84;З;88;И;85;Й;86;К;4B;Л;87;М;96;Н;AD;О;4F;П;8C;Р;50;С;43;Т;8F;У;59;Ф;81;Х;58;Ц;89;Ч;8D;Ш;8E;Щ;8A;Ъ;90;Ы;91;Ь;92;Э;93;Ю;94;Я;95;а;61;б;97;в;A2;г;99;д;9A;е;65;ё;B8;ж;9B;з;9F;и;9C;й;9D;к;6B;л;9E;м;AF;н;AE;о;6F;п;A3;р;70;с;63;т;A6;у;79;ф;98;х;78;ц;A0;ч;A4;ш;A5;щ;A1;ъ;A7;ы;A8;ь;A9;э;AA;ю;AB;я;AC"
![gtasa3](https://user-images.githubusercontent.com/16019388/214413817-4205ed43-bdff-4128-8161-e7c67244a03b.jpg)
